### PR TITLE
Update rules/show_your_creation/rules.markdown

### DIFF
--- a/rules/show_your_creation/rules.markdown
+++ b/rules/show_your_creation/rules.markdown
@@ -6,6 +6,7 @@
 * One thread per creation
 * You may only post your own work, not the work of others
 * Constructive criticism is encouraged, being rude is not
+* Excessive caps and symbols are not allowed in titles
 
 ## Screenshots
 
@@ -35,6 +36,7 @@ following Mapping and Modding sub-section instead:
     posted multiple times will be removed from each location.
 
 * Griefing videos are not allowed
+* Posts to announce a livestream restarting are allowed
 
 ## Videos / Series Help
 


### PR DESCRIPTION
added a rule to say excessive caps/symbols shouldn't be in titles - people use them to try to get more attention to their creation and it makes the whole place look messy.
added a rule that posting to announce a livestream going live again (bumping the thread) is acceptable as it stops dupe threads and lets people know the livestream is up again
