### PR TITLE
Final update

### DIFF
--- a/rules/support/rules.markdown
+++ b/rules/support/rules.markdown
@@ -16,7 +16,7 @@
     
 * __Do not Redistribute property of Mojang__
 
-    Do not distribute any property of Mojang to other members on the forum, link them to a download if possible.  This includes: the minecraft launcher, the minecraft Jar, and the Minecraft server client.
+    Do not distribute any property of Mojang to other members on the forum.  This includes: the minecraft launcher, the minecraft Jar, and the Minecraft server client.
 
 * __Do not give out or request personal information__
 


### PR DESCRIPTION
Got rid of the line saying link to a download as people can link to a mediafire download and say that they didn't break any rules. 
