### PR TITLE
Update rules/other_platforms/rules.markdown

### DIFF
--- a/rules/other_platforms/rules.markdown
+++ b/rules/other_platforms/rules.markdown
@@ -1,19 +1,19 @@
 # Other Platforms
 
-## Minecraft: Pocket Edition
-
 * __Do not partake in or create platform wars__
 
     Please do not make threads or comments regarding one platform being better than the other as they encourage flame wars within the community. 
+
+* __Do not post update threads__
+
+    Threads requesting dates on when a certain update is to be released are not allowed. They are considered to be spamming the section as they have no discussion value. Such threads will be locked for redundancy.
+
+## Minecraft: Pocket Edition
 
 * __Do not encourage the use of "cracked" applications__
 
     Please do not detail information on how to obtain pirated applications as it is encouraging piracy and will not be permitted on the forums.
     
-* __Do not post update threads__
-
-    Threads requesting dates on when a certain update is to be released are not allowed. They are considered to be spamming the section as they have no discussion value. Such threads will be locked for redundancy.
-        
 ### Pocket Edition: Maps
 
 * Map threads must include a download link to the map


### PR DESCRIPTION
I believe the two rules for "Do not partake in or create platform wars" 
and "Do not post update threads" should be a general rule for
Other Platforms instead of just a Pocket Edition specific. 

The Xbox section has to deal with the occasional "PC is better then 
Xbox" and vise-versa, and there is already a Pinned Twitter topic with 
a link to all known updates for the Xbox.

This should reduce the spam of topics asking about when updates are
and a way to keep people from causing drama with what platform
they believe is better, be it Xbox, PC, or Mobile Device. 
