### PR TITLE
Add a rule to not quote lengthy OPs

### DIFF
--- a/rules/global/rules.markdown
+++ b/rules/global/rules.markdown
@@ -101,9 +101,9 @@ The guidelines and information below applies to the entire forum.
     eg: "Stop trolling", "You're a troll!". If someone is trolling they should be 
     reported.
 
-*__Fully Quote Lengthy OPs__
+* __Quote Lenghty OPs__
 
-    "OP" stands for Original Post, as in the opening post of a thread. Do not quote 
+    OP stands for Original Post, as in the opening post of a thread. Do not quote 
     the entirity of these posts if they prove lengthy.
    
 ### Illegal Activity

--- a/rules/global/rules.markdown
+++ b/rules/global/rules.markdown
@@ -100,7 +100,12 @@ The guidelines and information below applies to the entire forum.
     Accusing someone of trolling, which is known as "Troll Calling" is also disallowed, 
     eg: "Stop trolling", "You're a troll!". If someone is trolling they should be 
     reported.
-    
+
+*__Fully Quote Lengthy OPs__
+
+    "OP" stands for Original Post, as in the opening post of a thread. Do not quote 
+    the entirity of these posts if they prove lengthy.
+   
 ### Illegal Activity
 
 * __Piracy__


### PR DESCRIPTION
Quoting big OPs has been a problem for a while, I hate it, and I'm sure I'm not the only one that does so, when someone quotes a massive OP just to say "cool mod" or something. This rule tries to stop that.
