### PR TITLE
Update rules.markdown

### DIFF
--- a/rules/minecraft_pocket_edition/rules.markdown
+++ b/rules/minecraft_pocket_edition/rules.markdown
@@ -54,6 +54,7 @@ Small suggestions should be posted in the [Pocket Edition small suggestions thre
 The root of the Mapping and Modding forum is for mod related topics that aren't specifically Pocket Edition maps, texture packs or mods/tools.
 
 * No linking to sites that require a person to do surveys or require personal information, such as cell phone numbers
+* "No pics, no clicks" are considered spam, and are not allowed
 
 ### Maps
 


### PR DESCRIPTION
We never required pictures to be uploaded with the Mods/Texture Packs/Maps for PE due to the fact that it is harder from some users to provide images from their smart devices.  I figured that the "No picks, no clicks" rule should apply to our sections as well.
