### PR TITLE
Clarifying Porting and moving it to the main rules instead of just under Maps

### DIFF
--- a/rules/minecraft_pocket_edition/rules.markdown
+++ b/rules/minecraft_pocket_edition/rules.markdown
@@ -75,7 +75,7 @@ This section is for posting and discussing seeds for worlds that are considered 
 
 * No linking to sites that require a person to do surveys or require personal information, such as cell phone numbers
 * "No pics, no clicks" are considered spam, and are not allowed
-* __Porting maps, texture packs $ mods__
+* __Porting maps, texture packs & mods__
 
   If you're porting a map, texture pack, or mod from another platform then permissions from the original author must be gained and clearly displayed within the topic.
 

--- a/rules/minecraft_pocket_edition/rules.markdown
+++ b/rules/minecraft_pocket_edition/rules.markdown
@@ -75,6 +75,9 @@ This section is for posting and discussing seeds for worlds that are considered 
 
 * No linking to sites that require a person to do surveys or require personal information, such as cell phone numbers
 * "No pics, no clicks" are considered spam, and are not allowed
+* __Porting maps, texture packs $ mods__
+
+  If you're porting a map, texture pack, or mod from another platform then permissions from the original author must be gained and clearly displayed within the topic.
 
 
 ### Maps
@@ -88,10 +91,6 @@ This section is for posting and discussing seeds for worlds that are considered 
 * __Label topics__
 
   Please label topics according to what platform it will work with whether it be iOS, Android or both.
-
-* __Porting maps & texture packs__
-
-  If you're porting a map or texture pack from another platform then permissions from the original author must be gained and clearly displayed within the topic.
 
 
 ### Mods / Tools

--- a/rules/minecraft_pocket_edition/rules.markdown
+++ b/rules/minecraft_pocket_edition/rules.markdown
@@ -10,7 +10,7 @@
 
 * __Porting maps, texture packs & mods__
 
-  If you're porting a map, texture pack, or mod from another platform then permissions from the original author must be clearly displayed within the topic.
+  If you're porting a map, texture pack, or mod from another platform then permission from the original author must be clearly displayed within the topic.
 
 
 ## Discussion

--- a/rules/minecraft_pocket_edition/rules.markdown
+++ b/rules/minecraft_pocket_edition/rules.markdown
@@ -8,6 +8,10 @@
 
   Topics requesting dates on when a certain update is to be released are not allowed. They are considered to be spamming the section as they have no discussion value. Such topics will be locked for redundancy.
 
+* __Porting maps, texture packs & mods__
+
+  If you're porting a map, texture pack, or mod from another platform then permissions from the original author must be clearly displayed within the topic.
+
 
 ## Discussion
 
@@ -75,9 +79,6 @@ This section is for posting and discussing seeds for worlds that are considered 
 
 * No linking to sites that require a person to do surveys or require personal information, such as cell phone numbers
 * "No pics, no clicks" are considered spam, and are not allowed
-* __Porting maps, texture packs & mods__
-
-  If you're porting a map, texture pack, or mod from another platform then permissions from the original author must be gained and clearly displayed within the topic.
 
 
 ### Maps


### PR DESCRIPTION
As the rules say right now, for porting, it doesn't say users can't port a PC mod without permission.  To limit confusion, I thought this should be clarified within the rules.
