### PR TITLE
Limit topic creation to hosts only

### DIFF
--- a/rules/servers/rules.markdown
+++ b/rules/servers/rules.markdown
@@ -103,7 +103,7 @@ IP to a server with no description or refer the user to a signature
 * No host may post in the topic of any other host. Host-to-host conversation must be taken to a PM
 * Hosts may offer giveaways in their topic, however the topic is not to be used for posting entries
 * Topics must pertain to Minecraft based hosting. Advertising non-Minecraft specific hosting is not allowed.
-
+* Topics in the Other Hosts section must be created by a representitive of a company. Members may not create a topic to advertise a host whom they use or recommend.
 
 ### Hosting Requests
 

--- a/rules/servers/rules.markdown
+++ b/rules/servers/rules.markdown
@@ -103,7 +103,7 @@ IP to a server with no description or refer the user to a signature
 * No host may post in the topic of any other host. Host-to-host conversation must be taken to a PM
 * Hosts may offer giveaways in their topic, however the topic is not to be used for posting entries
 * Topics must pertain to Minecraft based hosting. Advertising non-Minecraft specific hosting is not allowed.
-* Topics in the Other Hosts section must be created by a representative of a company. Members may not create a topic to advertise a host whom they use or recommend.
+* Topics must be created by a representative of a company. Members may not create a topic to advertise a host whom they use or recommend.
 
 ### Hosting Requests
 

--- a/rules/servers/rules.markdown
+++ b/rules/servers/rules.markdown
@@ -103,7 +103,7 @@ IP to a server with no description or refer the user to a signature
 * No host may post in the topic of any other host. Host-to-host conversation must be taken to a PM
 * Hosts may offer giveaways in their topic, however the topic is not to be used for posting entries
 * Topics must pertain to Minecraft based hosting. Advertising non-Minecraft specific hosting is not allowed.
-* Topics in the Other Hosts section must be created by a representitive of a company. Members may not create a topic to advertise a host whom they use or recommend.
+* Topics in the Other Hosts section must be created by a representative of a company. Members may not create a topic to advertise a host whom they use or recommend.
 
 ### Hosting Requests
 


### PR DESCRIPTION
Should prevent messes that occur when users make topics about a host they use which can cause duplicate topics, affiliate link spam, and so on.

Plus, if a user makes a topic, people can't get answers directly from the company.
