### PR TITLE
Prevent monetary offers

### DIFF
--- a/rules/servers/rules.markdown
+++ b/rules/servers/rules.markdown
@@ -89,6 +89,7 @@ This section is dedicated to multiplayer servers for the PC edition of Minecraft
 * Replies to a topic must follow the guidelines outlined in the original post
 * Replies must include all information needed, they cannot just provide a link to a topic/site, leave only a
 IP to a server with no description or refer the user to a signature
+* As the forum does not handle monetary transactions, monetary offers are not permitted. Any reports about being "scammed" or "x is a scammer" will be ignored.
 
 
 ## Minecraft Server Hosting


### PR DESCRIPTION
In an effort to protect users, removing the ability for there to be monetary offers. This is just using the idea that buying/selling stuff is not what the forum is for and any reports on it will not be handled.
Mimics the SYC shops rule, however disallows buying/selling
