### PR TITLE
Update rules.markdown

### DIFF
--- a/rules/global/rules.markdown
+++ b/rules/global/rules.markdown
@@ -119,7 +119,7 @@ The guidelines and information below applies to the entire forum.
 
 * __Breach Privacy__
 
-    Posting other peoples private information is not tolerated. Private information includes but is not limited to: real names, family names, photographs, email addresses, telephone numbers, Skype details, physical addresses.
+    Posting other peoples private information (even if the information is publicly available from sources like a domain WHOIS search) is not tolerated. Private information includes but is not limited to: real names, family names, photographs, email addresses, telephone numbers, Skype details, physical addresses.
 
 * __Impersonate__
 


### PR DESCRIPTION
added a bit in the "do not post private information" to clear up the apparent confusion about not posting private information even if that information is publicly available (i.e through a WHOIS search on a domain)
